### PR TITLE
Fix resources/tmres.dtd path

### DIFF
--- a/src/main/java/tm/TMFileResources.java
+++ b/src/main/java/tm/TMFileResources.java
@@ -281,7 +281,7 @@ public class TMFileResources {
 	public String toXML() {
 		StringBuffer sb = new StringBuffer();
 		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-		sb.append("<!DOCTYPE tmres SYSTEM \"resources\\tmres.dtd\">\n");
+		sb.append("<!DOCTYPE tmres SYSTEM \"resources" + File.separatorChar + "tmres.dtd\">\n");
 		sb.append("<tmres>\n");
 
 		sb.append(bookmarksToXML());


### PR DESCRIPTION
The program hardcoded the file seperator to be the windows backslash `\`. This leads to huge issues on non-windows machines like Linux, since an error will be thrown on every file load and resulting in the deletion of all bookmarks associated with that file.

This small change replaces the harcoded backslash with the OS specific path seperator.

fixes #13 
fixes #20 