### PR TITLE
Fix XML parser DTD resolution and TMView resize race

### DIFF
--- a/src/main/java/tm/TMFileResources.java
+++ b/src/main/java/tm/TMFileResources.java
@@ -281,7 +281,6 @@ public class TMFileResources {
 	public String toXML() {
 		StringBuffer sb = new StringBuffer();
 		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-		sb.append("<!DOCTYPE tmres SYSTEM \"resources\\tmres.dtd\">\n");
 		sb.append("<tmres>\n");
 
 		sb.append(bookmarksToXML());

--- a/src/main/java/tm/ui/TMUI.java
+++ b/src/main/java/tm/ui/TMUI.java
@@ -4447,6 +4447,11 @@ public class TMUI extends JFrame {
 						"Tile Molester",
 						JOptionPane.ERROR_MESSAGE);
 			}
+			// if loading failed (no resources attached), fall back to defaults
+			// so saving on close still produces a usable XML next time.
+			if (img.getResources() == null) {
+				new TMFileResources(img, this);
+			}
 		} else {
 			// create default resources
 			new TMFileResources(img, this);

--- a/src/main/java/tm/ui/TMView.java
+++ b/src/main/java/tm/ui/TMView.java
@@ -110,6 +110,7 @@ public class TMView extends JInternalFrame {
 
 		addComponentListener(new ComponentAdapter() {
 			public void componentResized(ComponentEvent e) {
+				if (editorCanvas == null) return;
 				slider.setSize(slider.getWidth(), editorCanvas.getHeight());
 				// slider.setSize(slider.getWidth(),
 				// getHeight()-((BasicInternalFrameUI)getUI()).getNorthPane().getHeight());

--- a/src/main/java/tm/utils/XMLParser.java
+++ b/src/main/java/tm/utils/XMLParser.java
@@ -45,9 +45,16 @@ public class XMLParser {
 			throws SAXException, SAXParseException, ParserConfigurationException, IOException {
 		Document document = null;
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-		factory.setValidating(true);
+		factory.setValidating(false);
+		try {
+			factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		} catch (Exception ignored) {}
 		try {
 			DocumentBuilder builder = factory.newDocumentBuilder();
+			// suppress any external entity (e.g. DTD) lookup — the resources XML
+			// references a relative DTD path that doesn't resolve on every OS.
+			builder.setEntityResolver((publicId, systemId) ->
+					new InputSource(new java.io.StringReader("")));
 			InputStream inputStream = new FileInputStream(file);
 			InputSource is = new InputSource(inputStream);
 			is.setEncoding("UTF-8");


### PR DESCRIPTION
## Summary

Three small, independent fixes that surface together when opening files on macOS / Linux. With these in place, per-file resources (bookmarks, palettes) load correctly on those platforms again.

## Bugs fixed

### 1. `XMLParser` cannot load any per-file resources XML on macOS/Linux
The resources XML carries `<!DOCTYPE tmres SYSTEM \"resources\\tmres.dtd\">`. With `setValidating(true)` the JDK parser tries to resolve that as a URI; the backslash and the relative path mean it fails on non-Windows with `no protocol: resources\\tmres.dtd`. The `IOException` propagates up to `TMUI.openFile`, the `FileImage` ends up without a `TMFileResources`, and the user's bookmarks/palettes silently disappear.

**Fix:** `setValidating(false)` plus a no-op `EntityResolver` that returns an empty input source for any external entity. Validation buys nothing here — the DTD isn't shipped in any build configuration I can find — and dropping it makes the parser portable.

### 2. `TMFileResources.toXML` keeps emitting the broken DTD reference
Even after the parser fix, every newly written XML still re-emitted the unresolvable DTD line, so any other XML consumer (or a future re-enabled validation) would hit the same failure. Removed it.

### 3. `TMView` `componentResized` listener can NPE on `editorCanvas`
The component listener is registered before `editorCanvas` is assigned in the constructor. Any layout pass that fires a resize event between those two points throws \`NullPointerException: ... editorCanvas is null\`. I have a reliable repro on macOS once any code triggers a `revalidate()` on the content pane while the frame is still being constructed. Cheap one-line guard.

### 4. `TMUI.openFile` leaves `FileImage` resource-less after a load failure
If parsing the resources XML throws, the catch block shows a dialog but never falls back to creating empty default resources. Closing the file then writes nothing, so anything the user added during the session (e.g. a fresh bookmark) is lost. Added the same default-resources fallback that the no-XML branch already uses.

## Test plan

- [x] Build with `mvn package` (Java 17)
- [x] Open a file on macOS that previously triggered the parse error → no dialog, bookmarks/palettes load
- [x] Add bookmark, close → XML written without the DTD line, reopens cleanly
- [x] Open file repeatedly with various codecs/zooms → no NPE in the resize listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)