### PR TITLE
Persist per-file view settings (codec, mode, zoom, canvas, offset, palette)

### DIFF
--- a/src/main/java/tm/TMFileResources.java
+++ b/src/main/java/tm/TMFileResources.java
@@ -281,7 +281,6 @@ public class TMFileResources {
 	public String toXML() {
 		StringBuffer sb = new StringBuffer();
 		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-		sb.append("<!DOCTYPE tmres SYSTEM \"resources\\tmres.dtd\">\n");
 		sb.append("<tmres>\n");
 
 		sb.append(bookmarksToXML());

--- a/src/main/java/tm/TMFileResources.java
+++ b/src/main/java/tm/TMFileResources.java
@@ -43,6 +43,7 @@ public class TMFileResources {
 
 	private FolderNode bookmarkRoot;
 	private FolderNode paletteRoot;
+	private ViewSettings viewSettings = new ViewSettings();
 
 	private FileImage fileImage;
 	private TMUI ui;
@@ -95,6 +96,8 @@ public class TMFileResources {
 		Element root = doc.getDocumentElement();
 		bookmarkRoot = parseBookmarks(root);
 		paletteRoot = parsePalettes(root);
+		ViewSettings parsed = ViewSettings.parse(root);
+		if (parsed != null) viewSettings = parsed;
 
 		fileImage.setResources(this);
 	}
@@ -274,6 +277,17 @@ public class TMFileResources {
 
 	/**
 	 *
+	 * Gets the per-file view settings (codec, mode, zoom, canvas size,
+	 * last externally-imported palette).
+	 *
+	 **/
+
+	public ViewSettings getViewSettings() {
+		return viewSettings;
+	}
+
+	/**
+	 *
 	 * Returns XML representation of resources.
 	 *
 	 **/
@@ -285,6 +299,7 @@ public class TMFileResources {
 
 		sb.append(bookmarksToXML());
 		sb.append(palettesToXML());
+		sb.append(viewSettings.toXML());
 
 		sb.append("</tmres>\n");
 		return sb.toString();

--- a/src/main/java/tm/ViewSettings.java
+++ b/src/main/java/tm/ViewSettings.java
@@ -1,0 +1,167 @@
+/*
+*
+*    Per-file view settings (codec, mode, zoom, canvas size,
+*    last externally-imported palette). Persisted alongside
+*    bookmarks/palettes in the resources XML, applied on open,
+*    captured on close.
+*
+*/
+
+package tm;
+
+import tm.colorcodecs.ColorCodec;
+import tm.tilecodecs.TileCodec;
+import tm.ui.TMUI;
+import tm.ui.TMView;
+import org.w3c.dom.Element;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+
+public class ViewSettings {
+
+	private String codecID;
+	private Integer mode;
+	private Double zoom;
+	private Integer cols;
+	private Integer rows;
+	private Integer offset;
+
+	private boolean hasExternalPalette;
+	private String palettePath;
+	private int paletteOffset;
+	private int paletteSize;
+	private String paletteCodecID;
+	private int paletteEndianness;
+
+	public ViewSettings() {}
+
+	public static ViewSettings parse(Element root) {
+		Element e = (Element) root.getElementsByTagName("viewsettings").item(0);
+		if (e == null) return null;
+
+		ViewSettings vs = new ViewSettings();
+		if (e.hasAttribute("codec")) {
+			vs.codecID = e.getAttribute("codec");
+		}
+		if (e.hasAttribute("mode")) {
+			vs.mode = e.getAttribute("mode").equals("2D") ? TileCodec.MODE_2D : TileCodec.MODE_1D;
+		}
+		if (e.hasAttribute("zoom")) {
+			try { vs.zoom = Double.parseDouble(e.getAttribute("zoom")); }
+			catch (NumberFormatException ignored) {}
+		}
+		if (e.hasAttribute("cols")) {
+			try { vs.cols = Integer.parseInt(e.getAttribute("cols")); }
+			catch (NumberFormatException ignored) {}
+		}
+		if (e.hasAttribute("rows")) {
+			try { vs.rows = Integer.parseInt(e.getAttribute("rows")); }
+			catch (NumberFormatException ignored) {}
+		}
+		if (e.hasAttribute("offset")) {
+			try { vs.offset = Integer.parseInt(e.getAttribute("offset")); }
+			catch (NumberFormatException ignored) {}
+		}
+
+		Element ep = (Element) e.getElementsByTagName("externalpalette").item(0);
+		if (ep != null && ep.hasAttribute("path") && ep.hasAttribute("offset")
+				&& ep.hasAttribute("size") && ep.hasAttribute("codec")) {
+			try {
+				vs.palettePath = ep.getAttribute("path");
+				vs.paletteOffset = Integer.parseInt(ep.getAttribute("offset"));
+				vs.paletteSize = Integer.parseInt(ep.getAttribute("size"));
+				vs.paletteCodecID = ep.getAttribute("codec");
+				vs.paletteEndianness = ep.getAttribute("endianness").equals("big")
+						? ColorCodec.BIG_ENDIAN : ColorCodec.LITTLE_ENDIAN;
+				vs.hasExternalPalette = true;
+			} catch (NumberFormatException ignored) {}
+		}
+
+		return vs;
+	}
+
+	public String toXML() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(" <viewsettings");
+		if (codecID != null) sb.append(" codec=\"").append(escape(codecID)).append("\"");
+		if (mode != null) sb.append(" mode=\"").append(mode == TileCodec.MODE_2D ? "2D" : "1D").append("\"");
+		if (zoom != null) sb.append(" zoom=\"").append(zoom).append("\"");
+		if (cols != null) sb.append(" cols=\"").append(cols).append("\"");
+		if (rows != null) sb.append(" rows=\"").append(rows).append("\"");
+		if (offset != null) sb.append(" offset=\"").append(offset).append("\"");
+
+		if (hasExternalPalette) {
+			sb.append(">\n");
+			sb.append("  <externalpalette");
+			sb.append(" path=\"").append(escape(palettePath)).append("\"");
+			sb.append(" offset=\"").append(paletteOffset).append("\"");
+			sb.append(" size=\"").append(paletteSize).append("\"");
+			sb.append(" codec=\"").append(escape(paletteCodecID)).append("\"");
+			sb.append(" endianness=\"")
+					.append(paletteEndianness == ColorCodec.BIG_ENDIAN ? "big" : "little")
+					.append("\"/>\n");
+			sb.append(" </viewsettings>\n");
+		} else {
+			sb.append("/>\n");
+		}
+		return sb.toString();
+	}
+
+	public void captureFrom(TMView view) {
+		TileCodec tc = view.getTileCodec();
+		if (tc != null) codecID = tc.getID();
+		mode = view.getMode();
+		zoom = view.getScale();
+		cols = view.getCols();
+		rows = view.getRows();
+		offset = view.getOffset();
+	}
+
+	public void applyTo(TMView view, TMUI ui) {
+		if (codecID != null) {
+			TileCodec tc = ui.getTileCodecByID(codecID);
+			if (tc != null) view.setTileCodec(tc);
+		}
+		if (mode != null) view.setMode(mode);
+		if (cols != null && rows != null) view.setGridSize(cols, rows);
+		if (zoom != null) view.setScale(zoom);
+		if (hasExternalPalette) applyExternalPalette(view, ui);
+		// offset must be applied last: setGridSize/setScale recompute maxOffset
+		if (offset != null) view.setAbsoluteOffset(offset);
+	}
+
+	private void applyExternalPalette(TMView view, TMUI ui) {
+		File file = new File(palettePath);
+		if (!file.exists()) return;
+		ColorCodec codec = ui.getColorCodecByID(paletteCodecID);
+		if (codec == null) return;
+
+		byte[] data = new byte[paletteSize * codec.getBytesPerPixel()];
+		try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+			raf.seek(paletteOffset);
+			raf.read(data);
+		} catch (Exception ex) {
+			return;
+		}
+
+		TMPalette palette = new TMPalette("ID", data, 0, paletteSize, codec, paletteEndianness, true, false);
+		view.setPalette(palette);
+	}
+
+	public void setExternalPalette(String path, int offset, int size, String codecID, int endianness) {
+		this.palettePath = path;
+		this.paletteOffset = offset;
+		this.paletteSize = size;
+		this.paletteCodecID = codecID;
+		this.paletteEndianness = endianness;
+		this.hasExternalPalette = true;
+	}
+
+	private static String escape(String s) {
+		return s.replace("&", "&amp;")
+				.replace("\"", "&quot;")
+				.replace("<", "&lt;")
+				.replace(">", "&gt;");
+	}
+}

--- a/src/main/java/tm/ui/TMUI.java
+++ b/src/main/java/tm/ui/TMUI.java
@@ -3811,6 +3811,7 @@ public class TMUI extends JFrame {
 		desktop.add(view);
 		try {
 			view.setSelected(true);
+			view.setMaximum(true);
 		} catch (java.beans.PropertyVetoException x) {
 			x.printStackTrace();
 		}
@@ -3933,7 +3934,7 @@ public class TMUI extends JFrame {
 		TMFileFilter supportedFilter = new TMFileFilter(extlist, xlate("All_Supported_Formats"));
 		fileOpenChooser.addChoosableFileFilter(supportedFilter);
 		fileOpenChooser.addChoosableFileFilter(allFilter);
-		fileOpenChooser.setFileFilter(supportedFilter);
+		fileOpenChooser.setFileFilter(allFilter);
 	}
 
 	/**

--- a/src/main/java/tm/ui/TMUI.java
+++ b/src/main/java/tm/ui/TMUI.java
@@ -1901,6 +1901,7 @@ public class TMUI extends JFrame {
 
 			// check if it's the last view
 			if (img.getViews().length == 1) {
+				captureViewSettings(view);
 				saveResources(img); // TODO
 				// check if saving required/desired
 				if (img.isModified()) {
@@ -1955,6 +1956,23 @@ public class TMUI extends JFrame {
 	 * Saves the resources for the given fileimage to a file in XML format.
 	 *
 	 **/
+
+	/**
+	 *
+	 * Captures the current view's codec/mode/zoom/canvas size into the
+	 * fileimage's resources, so they get persisted by saveResources().
+	 * The external-palette block is updated separately, when the user
+	 * runs Palette > Import From > Another File.
+	 *
+	 **/
+
+	public void captureViewSettings(TMView view) {
+		if (view == null) return;
+		FileImage img = view.getFileImage();
+		if (img == null || img.getResources() == null) return;
+		ViewSettings vs = img.getResources().getViewSettings();
+		if (vs != null) vs.captureFrom(view);
+	}
 
 	public void saveResources(FileImage img) {
 		// TODO: should only save if # bookmarks | # of palettes > 0?
@@ -2025,6 +2043,7 @@ public class TMUI extends JFrame {
 			TMView view = (TMView) frames[i];
 			FileImage img = view.getFileImage();
 
+			captureViewSettings(view);
 			saveResources(img); // TODO
 
 			addToRecentFiles(new File(img.getFile().getAbsolutePath()));
@@ -3259,6 +3278,15 @@ public class TMUI extends JFrame {
 
 				// set the new palette
 				view.setPalette(palette);
+
+				// record the import so it can be reapplied when the file is reopened
+				FileImage img = view.getFileImage();
+				if (img != null && img.getResources() != null
+						&& img.getResources().getViewSettings() != null) {
+					img.getResources().getViewSettings().setExternalPalette(
+							file.getAbsolutePath(), offset, size, pf.getCodecID(), endianness);
+				}
+
 				refreshPalettePane();
 				refreshPalettesMenu();
 			}
@@ -4466,7 +4494,14 @@ public class TMUI extends JFrame {
 		TMPalette pal = new TMPalette("PAL000", TMPalette.defaultPalette, getColorCodecByID("CF01"),
 				ColorCodec.LITTLE_ENDIAN, true);
 
-		addViewToDesktop(createView(img, tc, pal, mode));
+		TMView view = createView(img, tc, pal, mode);
+		addViewToDesktop(view);
+
+		// Apply persisted per-file view settings (overrides file-filter defaults).
+		if (img.getResources() != null && img.getResources().getViewSettings() != null) {
+			img.getResources().getViewSettings().applyTo(view, this);
+			viewSelected(view);
+		}
 
 		Vector recentFiles = TileMolester.settings.getRecentFiles();
 		// Remove file from recentFiles, if it's there

--- a/src/main/java/tm/ui/TMUI.java
+++ b/src/main/java/tm/ui/TMUI.java
@@ -4447,6 +4447,11 @@ public class TMUI extends JFrame {
 						"Tile Molester",
 						JOptionPane.ERROR_MESSAGE);
 			}
+			// if loading failed (no resources attached), fall back to defaults
+			// so saving on close still produces a usable XML next time.
+			if (img.getResources() == null) {
+				new TMFileResources(img, this);
+			}
 		} else {
 			// create default resources
 			new TMFileResources(img, this);

--- a/src/main/java/tm/ui/TMView.java
+++ b/src/main/java/tm/ui/TMView.java
@@ -110,6 +110,7 @@ public class TMView extends JInternalFrame {
 
 		addComponentListener(new ComponentAdapter() {
 			public void componentResized(ComponentEvent e) {
+				if (editorCanvas == null) return;
 				slider.setSize(slider.getWidth(), editorCanvas.getHeight());
 				// slider.setSize(slider.getWidth(),
 				// getHeight()-((BasicInternalFrameUI)getUI()).getNorthPane().getHeight());

--- a/src/main/java/tm/utils/XMLParser.java
+++ b/src/main/java/tm/utils/XMLParser.java
@@ -45,9 +45,16 @@ public class XMLParser {
 			throws SAXException, SAXParseException, ParserConfigurationException, IOException {
 		Document document = null;
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-		factory.setValidating(true);
+		factory.setValidating(false);
+		try {
+			factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		} catch (Exception ignored) {}
 		try {
 			DocumentBuilder builder = factory.newDocumentBuilder();
+			// suppress any external entity (e.g. DTD) lookup — the resources XML
+			// references a relative DTD path that doesn't resolve on every OS.
+			builder.setEntityResolver((publicId, systemId) ->
+					new InputSource(new java.io.StringReader("")));
 			InputStream inputStream = new FileInputStream(file);
 			InputSource is = new InputSource(inputStream);
 			is.setEncoding("UTF-8");


### PR DESCRIPTION
## Summary

Tile Molester already persists bookmarks and palette folders per file in `./resources/<filename>.xml`. This PR extends the same XML with a `<viewsettings>` element that captures the rest of the view state, so reopening a file restores the workspace exactly where you left it instead of reverting to the file-filter defaults.

**Depends on #34** (the XML parser fix). Without it, the new `<viewsettings>` element loads correctly on Windows but is silently dropped on macOS/Linux. If #34 lands first, this PR's diff against master will shrink to just the feature.

## What gets remembered

| Setting | Source |
|---|---|
| Codec | `View > Codec` |
| Mode (1D/2D) | `View > Mode` |
| Zoom | `View > Zoom` |
| Canvas size (cols × rows) | `Image > Canvas Size...` |
| Slider/byte offset | any navigation: keyboard, slider, Goto, byte forward/back |
| Externally imported palette | `Palette > Import From > Another File...` (path + offset + size + codec ID + endianness) |

## Behaviour

- **On open:** if `<viewsettings>` exists, it is applied right after the view is created, overriding the file-filter defaults. Missing or unknown values (e.g. a codec ID that no longer exists, or an external palette file that was moved) are skipped silently — never an error dialog.
- **On close / on exit:** the current view state is captured and written into the same XML as bookmarks/palettes, mirroring the existing `saveResources` flow. No new save action, no extra prompts.
- **Backward compatible:** old XMLs without `<viewsettings>` open exactly as before.

## Two extra UX commits (separable)

Kept as their own commits so they can be dropped on review:

1. **Open files maximised** — `addViewToDesktop` calls `view.setMaximum(true)` so a freshly opened file fills the MDI area.
2. **Default file dialog to All Files (\*.\*)** — most files used with TM are ROM dumps with extensions the bundled filters don't match, so users tend to flip to "All Files" by hand on every open. The supported-formats filter is still listed and selectable.

If either of these is unwanted, drop the second commit (`1bd57f1`) — the core feature stands on its own.

## Test plan

- [x] Build with `mvn package` (Java 17)
- [x] Open a fresh ROM (no XML yet) → file-filter defaults apply, no errors
- [x] Adjust codec / zoom / canvas / offset / external palette, close, reopen → all restored
- [x] Open an old XML with bookmarks but no `<viewsettings>` → bookmarks still load, defaults apply
- [x] Set external palette, then move/rename the palette source file, reopen → falls back to default palette without error
- [x] Set codec, downgrade Tile Molester (no `<viewsettings>` parsing) → no crash, just ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)